### PR TITLE
 improve naming consistency in url-read service types

### DIFF
--- a/url-read/cmd/main.go
+++ b/url-read/cmd/main.go
@@ -40,11 +40,11 @@ func main() {
 
 	// Initialize DB repository
 	dbConfig := db.GetDBConfigFromEnv()
-	repo, err := db.NewMyURLRepository(logger, dbConfig.DSNString())
+	urlRepo, err := db.NewPostgresURLStore(logger, dbConfig.DSNString())
 	if err != nil {
 		logger.WithError(err).Fatal("Failed to initialize database repository")
 	}
-	defer repo.Close()
+	defer urlRepo.Close()
 	logger.Info("Connected to PostgreSQL database")
 
 	// Initialize Redis URL Cacher
@@ -60,16 +60,16 @@ func main() {
 		ConnMaxIdleTime: time.Minute * 5, // Close idle connections after 5 minutes
 	}
 
-	urlCacher, err := cache.NewRedisURLCacher(logger, redisOptions)
+	urlCache, err := cache.NewRedisURLCache(logger, redisOptions)
 	if err != nil {
 		logger.WithError(err).Fatal("Failed to initialize Redis URL cacher")
 	}
-	defer urlCacher.Close()
+	defer urlCache.Close()
 	logger.Info("Connected to Redis cache")
 
 	// Create gRPC server
 	grpcServer := grpc.NewServer()
-	urlReadService := urlread.NewUrlReadImplementation(logger, repo, urlCacher)
+	urlReadService := urlread.NewUrlReadImplementation(logger, urlRepo, urlCache)
 	proto.RegisterURLReaderServer(grpcServer, urlReadService)
 
 	// Start listening for gRPC requests

--- a/url-read/internal/cache/cache.go
+++ b/url-read/internal/cache/cache.go
@@ -11,42 +11,42 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// CachedURL represents a cached URL with its expiration time
-type CachedURL struct {
+// URLCacheEntry represents a cached URL with its expiration time
+type URLCacheEntry struct {
 	LongURL   string    `json:"longUrl"`
 	ExpiresAt time.Time `json:"expiresAt"`
 }
 
-// URLCacher defines the interface for caching URL mappings
-type URLCacher interface {
-	Get(ctx context.Context, shortURLCode string) (*CachedURL, error)
-	Set(ctx context.Context, shortURLCode string, cachedURL CachedURL) error
+// URLCache defines the interface for caching URL mappings
+type URLCache interface {
+	Get(ctx context.Context, shortURLCode string) (*URLCacheEntry, error)
+	Set(ctx context.Context, shortURLCode string, cacheEntry URLCacheEntry) error
 	Del(ctx context.Context, shortURLCode string) error
 	Close() error
 }
 
-// RedisURLCacher implements URLCacher interface for Redis cache
-type RedisURLCacher struct {
+// RedisURLCache implements URLCache interface for Redis cache
+type RedisURLCache struct {
 	client *redis.Client
 	logger *logrus.Logger
 }
 
-// NewRedisURLCacher creates a new Redis client for caching URL mappings
-func NewRedisURLCacher(logger *logrus.Logger, redisOptions *redis.Options) (*RedisURLCacher, error) {
+// NewRedisURLCache creates a new Redis client for caching URL mappings
+func NewRedisURLCache(logger *logrus.Logger, redisOptions *redis.Options) (*RedisURLCache, error) {
 	// Initialize Redis client
 	cache, err := initCache(redisOptions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize Redis cache: %w", err)
 	}
 
-	return &RedisURLCacher{
+	return &RedisURLCache{
 		client: cache,
 		logger: logger,
 	}, nil
 }
 
 // Del deletes Short URL Code from the Redis cache
-func (r *RedisURLCacher) Del(ctx context.Context, shortURLCode string) error {
+func (r *RedisURLCache) Del(ctx context.Context, shortURLCode string) error {
 	result, err := r.client.Del(ctx, shortURLCode).Result()
 	if err != nil {
 		r.logger.WithError(err).WithField("shortURLCode", shortURLCode).Error("Error deleting short URL Code from cache")
@@ -62,8 +62,8 @@ func (r *RedisURLCacher) Del(ctx context.Context, shortURLCode string) error {
 }
 
 // Get retrieves Long URL from the Redis cache by short URL Code
-// Returns CachedURL struct with longURL and calculated expiration time
-func (r *RedisURLCacher) Get(ctx context.Context, shortURLCode string) (*CachedURL, error) {
+// Returns URLCacheEntry struct with longURL and calculated expiration time
+func (r *RedisURLCache) Get(ctx context.Context, shortURLCode string) (*URLCacheEntry, error) {
 	// Get the long URL
 	longURL, err := r.client.Get(ctx, shortURLCode).Result()
 	if err != nil {
@@ -92,7 +92,7 @@ func (r *RedisURLCacher) Get(ctx context.Context, shortURLCode string) (*CachedU
 	}
 	// If TTL is -1 (no expiration) or -2 (key doesn't exist), expiresAt remains zero
 
-	cachedURL := &CachedURL{
+	cacheEntry := &URLCacheEntry{
 		LongURL:   longURL,
 		ExpiresAt: expiresAt,
 	}
@@ -104,34 +104,34 @@ func (r *RedisURLCacher) Get(ctx context.Context, shortURLCode string) (*CachedU
 		"ttl":          ttl,
 	}).Info("Cache HIT: Short URL Code found in cache")
 
-	return cachedURL, nil
+	return cacheEntry, nil
 }
 
 // Set stores Short URL Code and Long URL mapping in Redis cache with specified expiration time
-func (r *RedisURLCacher) Set(ctx context.Context, shortURLCode string, cachedURL CachedURL) error {
+func (r *RedisURLCache) Set(ctx context.Context, shortURLCode string, cacheEntry URLCacheEntry) error {
 	// Calculate TTL from absolute expiration time
 	// Negative and zero TTL validation will be done upstream
-	ttl := time.Until(cachedURL.ExpiresAt)
+	ttl := time.Until(cacheEntry.ExpiresAt)
 
-	err := r.client.Set(ctx, shortURLCode, cachedURL.LongURL, ttl).Err()
+	err := r.client.Set(ctx, shortURLCode, cacheEntry.LongURL, ttl).Err()
 	if err != nil {
 		r.logger.WithError(err).WithFields(logrus.Fields{
 			"shortURLCode": shortURLCode,
-			"longURL":      cachedURL.LongURL,
-			"expiresAt":    cachedURL.ExpiresAt,
+			"longURL":      cacheEntry.LongURL,
+			"expiresAt":    cacheEntry.ExpiresAt,
 		}).Error("Error storing long URL in cache")
 		return err
 	}
 	r.logger.WithFields(logrus.Fields{
 		"shortURLCode": shortURLCode,
-		"expiresAt":    cachedURL.ExpiresAt,
+		"expiresAt":    cacheEntry.ExpiresAt,
 		"ttl":          ttl,
 	}).Info("Short URL Code stored in cache")
 	return nil
 }
 
 // Close closes the Redis client connection
-func (r *RedisURLCacher) Close() error {
+func (r *RedisURLCache) Close() error {
 	return r.client.Close()
 }
 

--- a/url-read/internal/cache/cache_test.go
+++ b/url-read/internal/cache/cache_test.go
@@ -15,7 +15,7 @@ import (
 type URLCacheTestSuite struct {
 	suite.Suite
 	redisContainer *testhelpers.RedisContainer
-	cache          *RedisURLCacher
+	cache          *RedisURLCache
 	ctx            context.Context
 }
 
@@ -27,7 +27,7 @@ func (suite *URLCacheTestSuite) SetupSuite() {
 	}
 	suite.redisContainer = redisContainer
 	logger := logrus.New()
-	cache, err := NewRedisURLCacher(logger, suite.redisContainer.RedisOpts)
+	cache, err := NewRedisURLCache(logger, suite.redisContainer.RedisOpts)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -43,24 +43,24 @@ func (suite *URLCacheTestSuite) TearDownSuite() {
 	}
 }
 
-func (suite *URLCacheTestSuite) TestSetAndGet_CachedURL() {
+func (suite *URLCacheTestSuite) TestSetAndGet_URLCacheEntry() {
 	t := suite.T()
 	shortURLCode := "TEST123"
 	expiresAt := time.Now().Add(10 * time.Minute)
-	cachedURL := CachedURL{
+	URLCacheEntry := URLCacheEntry{
 		LongURL:   "https://example.com/long-url",
 		ExpiresAt: expiresAt,
 	}
 
 	// Set the cached URL
-	err := suite.cache.Set(suite.ctx, shortURLCode, cachedURL)
+	err := suite.cache.Set(suite.ctx, shortURLCode, URLCacheEntry)
 	assert.NoError(t, err, "Failed to set cached URL")
 
 	// Get the cached URL
 	retrievedURL, err := suite.cache.Get(suite.ctx, shortURLCode)
 	assert.NoError(t, err, "Failed to get cached URL")
 	assert.NotNil(t, retrievedURL, "Expected to retrieve a cached URL, got nil")
-	assert.Equal(t, cachedURL.LongURL, retrievedURL.LongURL, "LongURL should match")
+	assert.Equal(t, URLCacheEntry.LongURL, retrievedURL.LongURL, "LongURL should match")
 }
 
 func (suite *URLCacheTestSuite) TestGet_NonExistentKey() {

--- a/url-read/internal/db/db.go
+++ b/url-read/internal/db/db.go
@@ -13,69 +13,69 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type URLRepository interface {
-	GetLongURL(ctx context.Context, shortCode string) (*LongURLRecord, error)
+type URLStore interface {
+	GetLongURL(ctx context.Context, shortURLCode string) (*URLRecord, error)
 	Close() error
 }
 
-type MyURLRepository struct {
+type PostgresURLStore struct {
 	logger *logrus.Logger
 	db     *pgxpool.Pool
 }
 
-// NewMyURLRepository creates a new repository instance with database connection
-func NewMyURLRepository(logger *logrus.Logger, connectionString string) (*MyURLRepository, error) {
+// NewPostgresURLStore creates a new repository instance with database connection
+func NewPostgresURLStore(logger *logrus.Logger, connectionString string) (*PostgresURLStore, error) {
 	// Initialize database connection
 	db, err := initDB(connectionString)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize database: %w", err)
 	}
 
-	return &MyURLRepository{
+	return &PostgresURLStore{
 		logger: logger,
 		db:     db,
 	}, nil
 }
 
-func (r *MyURLRepository) Close() error {
+func (r *PostgresURLStore) Close() error {
 	r.db.Close()
 	return nil
 }
 
-type LongURLRecord struct {
+type URLRecord struct {
 	OriginalURL string
 	ExpiresAt   *time.Time
 }
 
-func (r *MyURLRepository) GetLongURL(ctx context.Context, shortCode string) (*LongURLRecord, error) {
+func (r *PostgresURLStore) GetLongURL(ctx context.Context, shortURLCode string) (*URLRecord, error) {
 	// SQL query to fetch the original URL by short code
 	query := `
 		SELECT original_url, expires_at
 		FROM short_links 
 		WHERE code = $1 AND (expires_at IS NULL OR expires_at > NOW())`
 
-	var response LongURLRecord
-	err := r.db.QueryRow(ctx, query, shortCode).Scan(&response.OriginalURL, &response.ExpiresAt)
+	var response URLRecord
+	err := r.db.QueryRow(ctx, query, shortURLCode).Scan(&response.OriginalURL, &response.ExpiresAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			r.logger.WithFields(logrus.Fields{
-				"shortCode": shortCode,
+				"shortURLCode": shortURLCode,
 			}).Info("Short URL not found in database")
-			return nil, fmt.Errorf("short URL '%s' not found", shortCode)
+			return nil, fmt.Errorf("short URL '%s' not found", shortURLCode)
 		}
 		r.logger.WithError(err).WithFields(logrus.Fields{
-			"shortCode": shortCode,
+			"shortURLCode": shortURLCode,
 		}).Error("Failed to fetch original URL from database")
 		return nil, fmt.Errorf("failed to retrieve URL: %w", err)
 	}
 
 	r.logger.WithFields(logrus.Fields{
-		"shortCode":   shortCode,
-		"originalURL": response.OriginalURL,
-		"expiresAt":   response.ExpiresAt,
+		"shortURLCode": shortURLCode,
+		"originalURL":  response.OriginalURL,
+		"expiresAt":    response.ExpiresAt,
 	}).Infof("Successfully fetched original URL from database")
 
-	return &LongURLRecord{
+	return &URLRecord{
 		OriginalURL: response.OriginalURL,
 		ExpiresAt:   response.ExpiresAt,
 	}, nil

--- a/url-read/internal/db/db_test.go
+++ b/url-read/internal/db/db_test.go
@@ -14,7 +14,7 @@ import (
 type URLRepoTestSuite struct {
 	suite.Suite
 	pgContainer *testhelpers.PostgresContainer
-	repository  *MyURLRepository
+	repository  *PostgresURLStore
 	ctx         context.Context
 }
 
@@ -27,7 +27,7 @@ func (suite *URLRepoTestSuite) SetupSuite() {
 	suite.pgContainer = pgContainer
 
 	logger := logrus.New()
-	repository, err := NewMyURLRepository(logger, suite.pgContainer.ConnectionString)
+	repository, err := NewPostgresURLStore(logger, suite.pgContainer.ConnectionString)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/url-read/internal/implementation/urlread.go
+++ b/url-read/internal/implementation/urlread.go
@@ -13,12 +13,12 @@ import (
 
 type Implementation struct {
 	logger *logrus.Logger
-	repo   repo.URLRepository
+	repo   repo.URLStore
 	uread.UnimplementedURLReaderServer
-	cache cache.URLCacher
+	cache cache.URLCache
 }
 
-func NewUrlReadImplementation(logger *logrus.Logger, repository repo.URLRepository, cache cache.URLCacher) *Implementation {
+func NewUrlReadImplementation(logger *logrus.Logger, repository repo.URLStore, cache cache.URLCache) *Implementation {
 	return &Implementation{
 		logger: logger,
 		repo:   repository,
@@ -32,13 +32,13 @@ func (s *Implementation) GetLongURL(ctx context.Context, request *uread.LongURLR
 	cacheResponse, err := s.cache.Get(ctx, request.ShortUrl)
 	if err != nil {
 		s.logger.WithContext(ctx).WithError(err).WithFields(logrus.Fields{
-			"shortCode": request.ShortUrl,
+			"shortURLCode": request.ShortUrl,
 		}).Errorf("Failed to retrieve original URL from cache: %v", err)
 	} else if cacheResponse != nil {
 		s.logger.WithContext(ctx).WithFields(logrus.Fields{
-			"shortCode":   request.ShortUrl,
-			"originalURL": cacheResponse.LongURL,
-			"expiration":  cacheResponse.ExpiresAt,
+			"shortURLCode": request.ShortUrl,
+			"originalURL":  cacheResponse.LongURL,
+			"expiration":   cacheResponse.ExpiresAt,
 		}).Debug("Successfully retrieved original URL from cache")
 		var expiration *timestamppb.Timestamp
 		if !cacheResponse.ExpiresAt.IsZero() {
@@ -55,15 +55,15 @@ func (s *Implementation) GetLongURL(ctx context.Context, request *uread.LongURLR
 	response, err := s.repo.GetLongURL(ctx, request.ShortUrl)
 	if err != nil {
 		s.logger.WithContext(ctx).WithError(err).WithFields(logrus.Fields{
-			"shortCode": request.ShortUrl,
+			"shortURLCode": request.ShortUrl,
 		}).Errorf("Failed to retrieve original URL from database: %v", err)
 		return nil, err
 	}
 
 	s.logger.WithContext(ctx).WithFields(logrus.Fields{
-		"shortCode":   request.ShortUrl,
-		"originalURL": response.OriginalURL,
-		"expiration":  response.ExpiresAt,
+		"shortURLCode": request.ShortUrl,
+		"originalURL":  response.OriginalURL,
+		"expiration":   response.ExpiresAt,
 	}).Debug("Successfully retrieved original URL from database")
 	var expiration *timestamppb.Timestamp
 	if response.ExpiresAt != nil {
@@ -77,23 +77,23 @@ func (s *Implementation) GetLongURL(ctx context.Context, request *uread.LongURLR
 		if response.ExpiresAt != nil {
 			expiresAt = *response.ExpiresAt
 		}
-		err = s.cache.Set(ctx, request.ShortUrl, cache.CachedURL{
+		err = s.cache.Set(ctx, request.ShortUrl, cache.URLCacheEntry{
 			LongURL:   response.OriginalURL,
 			ExpiresAt: expiresAt,
 		})
 		if err != nil {
 			s.logger.WithContext(ctx).WithError(err).WithFields(logrus.Fields{
-				"shortCode":   request.ShortUrl,
-				"originalURL": response.OriginalURL,
-				"expiration":  response.ExpiresAt,
+				"shortURLCode": request.ShortUrl,
+				"originalURL":  response.OriginalURL,
+				"expiration":   response.ExpiresAt,
 			}).Errorf("Failed to store original URL in cache: %v", err)
 			// Proceeding without failing the request, as we have the data from DB
 		}
 	} else {
 		s.logger.WithContext(ctx).WithFields(logrus.Fields{
-			"shortCode":   request.ShortUrl,
-			"originalURL": response.OriginalURL,
-			"expiration":  response.ExpiresAt,
+			"shortURLCode": request.ShortUrl,
+			"originalURL":  response.OriginalURL,
+			"expiration":   response.ExpiresAt,
 		}).Warn("Skipping cache storage for expired URL")
 	}
 


### PR DESCRIPTION
refactor(url-read): improve type naming consistency

Database Layer:
- Rename URLRepository → URLStore for clarity
- Rename MyURLRepository → PostgresURLStore for technology clarity
- Rename LongURLRecord → URLRecord for brevity

Cache Layer:
- Rename URLCacher → URLCache for consistency
- Rename CachedURL → URLCacheEntry for clarity
- Rename RedisURLCacher → RedisURLCache for consistency
- Rename NewRedisURLCacher → NewRedisURLCache for consistency

Update all references across url-read service
Maintain consistent naming pattern between cache and database layers
No functional changes, purely cosmetic refactoring.