### PR TITLE
construct full short URL in api-gateway

### DIFF
--- a/api-gateway/cmd/main.go
+++ b/api-gateway/cmd/main.go
@@ -174,6 +174,8 @@ func validateCreateRequest(req *CreateShortURLRequest) error {
 	return nil
 }
 
+const URLShortenerDomainName = "l.it"
+
 func (h *APIHandler) CreateShortURL(w http.ResponseWriter, r *http.Request) {
 	// Use request context for future enhancements such as logging, timeouts, tracing, etc.
 	ctx := r.Context()
@@ -208,6 +210,9 @@ func (h *APIHandler) CreateShortURL(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Failed to generate short URL", http.StatusInternalServerError)
 		return
 	}
+
+	// Prepend domain to the short URL code
+	response.ShortUrl = "http://" + URLShortenerDomainName + "/" + response.ShortUrl
 
 	// Respond with the short URL
 	responseJSON, err := json.Marshal(response)

--- a/url-gen/internal/implementation/urlgen.go
+++ b/url-gen/internal/implementation/urlgen.go
@@ -48,23 +48,18 @@ func (s *URLGenService) GenerateShortURL(ctx context.Context, URLRequestPayload 
 		return nil, err
 	}
 
-	// Return the full short URL
-	shortUrl := "http://" + URLShortenerDomainName + "/" + shortURLCode
-
 	s.logger.WithContext(ctx).WithFields(logrus.Fields{
 		"shortURLCode": shortURLCode,
-		"shortUrl":     shortUrl,
-	}).Info("Successfully generated short URL")
+	}).Info("Successfully generated short URL code")
 
 	return &ugen.ShortURLResponse{
-		ShortUrl: shortUrl,
+		ShortUrl: shortURLCode,
 	}, nil
 }
 
 const (
-	codeAlphabet           = "FxnXM1kBN6cuhsAvjW3Co7l2RePyY8DwaU04Tzt9fHQrqSVKdpimLGIJOgb5ZE"
-	codeLength             = 7 // 7-char length
-	URLShortenerDomainName = "l.it"
+	codeAlphabet = "FxnXM1kBN6cuhsAvjW3Co7l2RePyY8DwaU04Tzt9fHQrqSVKdpimLGIJOgb5ZE"
+	codeLength   = 7 // 7-char length
 )
 
 func shortCodeGenerator() (string, error) {

--- a/url-gen/internal/implementation/urlgen_test.go
+++ b/url-gen/internal/implementation/urlgen_test.go
@@ -2,7 +2,6 @@ package urlgen
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"testing"
 
@@ -49,8 +48,7 @@ func (c *URLGenServiceTestSuite) TestGenerateShortURL_Length() {
 	response, err := c.implementation.GenerateShortURL(c.ctx, &ugen.ShortURLRequest{LongUrl: "https://example.com/long-url-1"})
 	assert.NoError(t, err)
 	assert.NotNil(t, response)
-	fmt.Println(response.ShortUrl)
-	assert.Equal(t, 19, len(response.ShortUrl))
+	assert.Equal(t, 7, len(response.ShortUrl))
 }
 
 func (c *URLGenServiceTestSuite) TearDownSuite() {


### PR DESCRIPTION
keep `url-gen` simple
construct full short URL in api-gateway 
eg: http://l.it/{shortCode}