### PR TITLE
pin docker digests and use docker versioning for img updates

### DIFF
--- a/k8s/argocd/url-gen-app.yaml
+++ b/k8s/argocd/url-gen-app.yaml
@@ -18,7 +18,7 @@ spec:
       values: |
         image:
           repository: andreistefanciprian/urlshortener-url-gen
-          tag: main
+          tag: latest@sha256:bd964b5f5b233001a775bce1064d9ebc5171d6d3db73e77c0cc2d4c52d227023
         config:
           LOG_LEVEL: DEBUG
           DB_HOST: postgres-postgresql.postgres.svc

--- a/renovate.json
+++ b/renovate.json
@@ -22,7 +22,7 @@
         "repository:\\s*(?<depName>[^\\s]+)[\\s\\S]*?tag:\\s*(?<currentValue>[^\\s#]+)"
       ],
       "datasourceTemplate": "docker",
-      "versioningTemplate": "loose"
+      "versioningTemplate": "docker"
     }
   ],
   "packageRules": [
@@ -51,6 +51,12 @@
       "commitMessageAction": "bump",
       "commitMessageTopic": "{{depName}}",
       "commitMessageExtra": "to {{newVersion}}"
+    },
+    {
+      "description": "Pin digests for docker images found by regex manager",
+      "matchManagers": ["regex"],
+      "matchDatasources": ["docker"],
+      "pinDigests": true
     }
   ]
 }


### PR DESCRIPTION
Renovate fix: pin docker digests and use docker versioning for img updates